### PR TITLE
kubeadm-nspawn: Add a CLI for spawning the kubeadm dev environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,20 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+*.lck
+
+# vendor
+/vendor
+
+# binaries
+/cni-noop
+/cnispawn
+/kubeadm-systemd
+
+# ssh keys
+/id_rsa*
+
+# containers
+/kubeadm-systemd-*
+/rootfs.tar.xz

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+all: install-vendor
+	go build -o cni-noop ./cmd/cni-noop
+	go build -o cnispawn ./cmd/cnispawn
+	go build -o kubeadm-systemd ./cmd/kubeadm-systemd
+
+check-glide-installation:
+	@which glide || go get -u github.com/Masterminds/glide
+
+install-vendor: check-glide-installation
+	glide install --strip-vendor
+
+update-vendor: check-glide-installation
+	glide update --strip-vendor
+
+.PHONY: check-glide-installation install-vendor update-vendor all

--- a/README.md
+++ b/README.md
@@ -8,6 +8,223 @@ on a single machine, created mostly for developers __of__ Kubernetes.
 It aims to be as similar to the solutions recommendend for production
 clusters as possible.
 
+## Getting started
+
+### Build proper systemd-nspawn version
+
+Unfortunately, there is [one pending feature](https://github.com/systemd/systemd/pull/4395)
+of systemd-nspawn which is merged in master, but not released yet.
+You will need to build your own systemd-nspawn binary.
+
+We higly recommend using CoreOS' fork which backported that feature
+to the 231 version of systemd (which is the one that Fedora and
+the other popular distributions are using in its stable releases).
+
+In order to do that, please use the following commands:
+
+```
+git clone git@github.com:coreos/systemd.git
+cd systemd
+git checkout v231
+./autogen.sh
+./configure
+make
+```
+
+You **shoudn't** do `make install` after that! Using the custom
+systemd-nspawn binary with the other components of systemd being
+in another version is totally fine.
+
+You may try to use master branch from upstream systemd repository, but
+it's very risky!
+
+### Get needed Kubernetes repositories
+
+kubeadm-systemd needs the following repos to exist in your GOPATH:
+
+* [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes)
+* [kubernetes/release](https://github.com/kubernetes/release)
+
+Also, bulding Kubernetes may rely on having your own fork and the
+separate remote called `upstream`. In this HOWTO, we assume that
+you have these repositories forked.
+
+You can clone then by the following commands:
+
+```
+mkdir -p $GOPATH/src/k8s.io
+cd $GOPATH/src/k8s.io
+git clone git@github.com:<your_username>/kubernetes.git
+git clone git@github.com:<your_username>/release.git
+cd kubernetes
+git remote add upstream git@github.com:kubernetes/kubernetes.git
+cd ../release
+git remote add upstream git@github.com:kubernetes/release.git
+```
+
+### Build Kubernetes
+
+kubeadm-systemd needs the built Kubernetes binaries and hyperkube
+Docker image. You need to build them like that:
+
+```
+cd $GOPATH/src/k8s.io/kubernetes
+build/run.sh make
+build/copy-output.sh
+cd cluster/images/hyperkube
+make VERSION=latest
+```
+
+### Build CNI with plugins
+
+Firstly, you need to get a repo of CNI:
+
+```
+mkdir -p $GOPATH/src/github.com/containernetworking
+cd $GOPATH/src/github.com/containernetworking
+git clone git@github.com:containernetworking/cni.git
+```
+
+Then you can build CNI by doing:
+
+```
+cd cni
+./build.sh
+```
+
+And then configure CNI networks needed by kubeadm-systemd:
+
+```
+mkdir -p /etc/cni/net.d
+cat >/etc/cni/net.d/10-mynet.conf <<EOF
+{
+    "cniVersion": "0.2.0",
+    "name": "mynet",
+    "type": "bridge",
+    "bridge": "cni0",
+    "isGateway": true,
+    "ipMasq": true,
+    "ipam": {
+        "type": "host-local",
+        "subnet": "10.22.0.0/16",
+        "routes": [
+            { "dst": "0.0.0.0/0" }
+        ]
+    }
+}
+EOF
+cat >/etc/cni/net.d/99-loopback.conf <<EOF
+{
+    "cniVersion": "0.2.0",
+    "type": "loopback"
+}
+EOF
+```
+
+### Build and run kubeadm-systemd
+
+In the directory where you cloned this repository, please do:
+
+```
+make
+sudo GOPATH=$GOPATH SYSTEMD_NSPAWN_PATH=<path_to_your_nspawn_binary> ./kubeadm-systemd --nodes <number_of_nodes>
+```
+
+Sometimes when you Docker doesn't use the newest existing API, you may see
+the following error:
+
+```
+2017/01/26 16:41:38 Error when pushing image: Error response from daemon: client is newer than server (client API version: 1.26, server API version: 1.24)
+```
+
+Then wou will need to include your Docker API version in DOCKER_API_VERSION
+environment variable:
+
+```
+sudo GOPATH=$GOPATH SYSTEMD_NSPAWN_PATH=<path_to_your_nspawn_binary> DOCKER_API_VERSION=1.24 ./kubeadm-systemd --nodes <number_of_nodes>
+```
+
+The process of setting up the containers and running kubeadm
+in them will be very long! But finally, the last lines of the
+output should look like:
+
+```
+2017/01/26 16:13:13 Initializing master
+[kubeadm] WARNING: kubeadm is in alpha, please do not use it for production clusters.
+[init] Using Kubernetes version: v1.6.0-alpha.0
+[init] Using Authorization mode: AlwaysAllow
+[init] A token has not been provided, generating one
+[preflight] Skipping pre-flight checks
+[preflight] Starting the kubelet service
+[certificates] Generated CA certificate and key.
+[certificates] Generated API server certificate and key.
+[certificates] Generated API server kubelet client certificate and key.
+[certificates] Valid certificates and keys now exist in "/etc/kubernetes/pki"
+[kubeconfig] Wrote KubeConfig file to disk: "/etc/kubernetes/admin.conf"
+[kubeconfig] Wrote KubeConfig file to disk: "/etc/kubernetes/kubelet.conf"
+[apiclient] Created API client, waiting for the control plane to become ready
+[apiclient] All control plane components are healthy after 57.825192 seconds
+[apiclient] Waiting for at least one node to register and become ready
+[apiclient] First node is ready after 0.507054 seconds
+[apiclient] Creating a test deployment
+[apiclient] Test deployment succeeded
+[token-discovery] Using token: a85f41:7a45e1cac2e6b9a3
+[token-discovery] Created the kube-discovery deployment, waiting for it to become ready
+[token-discovery] kube-discovery is ready after 30.005429 seconds
+[addons] Created essential addon: kube-proxy
+[addons] Created essential addon: kube-dns
+
+Your Kubernetes master has initialized successfully!
+
+You should now deploy a pod network to the cluster.
+Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
+    http://kubernetes.io/docs/admin/addons/
+
+You can now join any number of machines by running the following on each node:
+
+kubeadm join --discovery token://a85f41:7a45e1cac2e6b9a3@10.22.0.206:9898
+2017/01/26 16:14:49 Joining node
+[kubeadm] WARNING: kubeadm is in alpha, please do not use it for production clusters.
+[preflight] Skipping pre-flight checks
+[preflight] Starting the kubelet service
+[discovery] Created cluster info discovery client, requesting info from "http://10.22.0.206:9898/cluster-info/v1/?token-id=a85f41"
+[discovery] Cluster info object received, verifying signature using given token
+[discovery] Cluster info signature and contents are valid, will use API endpoints [https://10.22.0.206:6443]
+[bootstrap] Trying to connect to endpoint https://10.22.0.206:6443
+[bootstrap] Detected server version: v1.2.0-alpha.7.18692+28c439dcfb0383-dirty
+[bootstrap] Successfully established connection with endpoint "https://10.22.0.206:6443"
+[csr] Created API client to obtain unique certificate for this node, generating keys and certificate signing request
+[csr] Received signed certificate from the API server[csr] Generating kubelet configuration
+[kubeconfig] Wrote KubeConfig file to disk: "/etc/kubernetes/kubelet.conf"
+
+Node join complete:
+* Certificate signing request sent to master and response
+  received.
+* Kubelet informed of new secure connection details.
+
+Run 'kubectl get nodes' on the master to see this machine join.
+2017/01/26 16:14:54 Joining node
+[kubeadm] WARNING: kubeadm is in alpha, please do not use it for production clusters.
+[preflight] Skipping pre-flight checks
+[preflight] Starting the kubelet service
+[discovery] Created cluster info discovery client, requesting info from "http://10.22.0.206:9898/cluster-info/v1/?token-id=a85f41"
+[discovery] Cluster info object received, verifying signature using given token
+[discovery] Cluster info signature and contents are valid, will use API endpoints [https://10.22.0.206:6443]
+[bootstrap] Trying to connect to endpoint https://10.22.0.206:6443
+[bootstrap] Detected server version: v1.2.0-alpha.7.18692+28c439dcfb0383-dirty
+[bootstrap] Successfully established connection with endpoint "https://10.22.0.206:6443"
+[csr] Created API client to obtain unique certificate for this node, generating keys and certificate signing request
+[csr] Received signed certificate from the API server[csr] Generating kubelet configuration
+[kubeconfig] Wrote KubeConfig file to disk: "/etc/kubernetes/kubelet.conf"
+
+Node join complete:
+* Certificate signing request sent to master and response
+  received.
+* Kubelet informed of new secure connection details.
+
+Run 'kubectl get nodes' on the master to see this machine join.
+```
+
 ## Architecture
 
 ![Architecture Diagram](architecture.png?raw=true "Architecture")

--- a/cmd/cni-noop/cni-noop.go
+++ b/cmd/cni-noop/cni-noop.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+	"runtime"
+
+	"github.com/kinvolk/kubeadm-systemd/pkg/cnispawn"
+)
+
+func main() {
+	runtime.LockOSThread()
+
+	cniNetns, err := cnispawn.NewCniNetns()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer cniNetns.Close()
+}

--- a/cmd/cnispawn/cnispawn.go
+++ b/cmd/cnispawn/cnispawn.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"log"
+
+	"github.com/kinvolk/kubeadm-systemd/pkg/cnispawn"
+)
+
+var (
+	path       = flag.String("path", "", "Path to the container to run")
+	background = flag.Bool("background", true, "Spawn the container in background")
+)
+
+func main() {
+	flag.Parse()
+	if err := cnispawn.RunContainer(*path, *background); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/kubeadm-systemd/kubeadm-systemd.go
+++ b/cmd/kubeadm-systemd/kubeadm-systemd.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kinvolk/kubeadm-systemd/pkg/bootstrap"
+	"github.com/kinvolk/kubeadm-systemd/pkg/distribution"
+	"github.com/kinvolk/kubeadm-systemd/pkg/nspawntool"
+	"github.com/kinvolk/kubeadm-systemd/pkg/ssh"
+	"github.com/kinvolk/kubeadm-systemd/pkg/utils"
+)
+
+const (
+	containerNameTemplate string = "kubeadm-systemd-%d"
+	pushImageRetries      int    = 10
+)
+
+var (
+	gopath string = os.Getenv("GOPATH")
+	nodes  int
+)
+
+func runUp(cmd *cobra.Command, args []string) {
+	if err := bootstrap.EnsureBridge(); err != nil {
+		log.Fatal("Error when checking CNI bridge: ", err)
+	}
+	if err := distribution.StartRegistry(); err != nil {
+		log.Fatal("Error when starting registry: ", err)
+	}
+
+	var err error
+	for i := 0; i < pushImageRetries; i++ {
+		err = distribution.PushImage()
+		if err == nil {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+	if err != nil {
+		log.Fatal("Error when pushing image: ", err)
+	}
+
+	if err := nspawntool.DownloadImage(); err != nil {
+		log.Fatal("Error when downloading image: ", err)
+	}
+	if err := ssh.PrepareSSHKeys(); err != nil {
+		log.Fatal("Error when generating SSH keys: ", err)
+	}
+
+	masterIpAddresses := make([]string, 0, 1)
+	nodeIpAddresses := make([]string, 0, nodes-1)
+
+	for i := 0; i < nodes; i++ {
+		name := getContainerName(i)
+
+		rootfsExists, err := bootstrap.ContainerRootfsExists(name)
+		if err != nil {
+			log.Fatal("Error when checking container rootfs directory: ", err)
+		}
+
+		if !rootfsExists {
+			if err := nspawntool.ExtractImage(name); err != nil {
+				log.Fatal("Error when extracting image: ", err)
+			}
+			if err := bootstrap.BootstrapContainer(name); err != nil {
+				log.Fatal("Error when bootstraping container :", err)
+			}
+		}
+
+		ip, err := nspawntool.RunContainer(name)
+		if err != nil {
+			log.Fatal("Error when running container: ", err)
+		}
+		if i < 1 {
+			masterIpAddresses = append(masterIpAddresses, ip)
+		} else {
+			nodeIpAddresses = append(nodeIpAddresses, ip)
+		}
+	}
+
+	for _, masterIpAddress := range masterIpAddresses {
+		if err := ssh.InitializeMaster(masterIpAddress); err != nil {
+			log.Fatal("Error when initializing master: ", err)
+		}
+	}
+
+	token, err := utils.GetToken("kubeadm-systemd-0")
+	if err != nil {
+		log.Fatal("Error when getting token: ", err)
+	}
+
+	for _, nodeIpAddress := range nodeIpAddresses {
+		if err := ssh.JoinNode(nodeIpAddress, token, masterIpAddresses[0]); err != nil {
+			log.Fatal("Error when joining node: ", err)
+		}
+	}
+}
+
+func newUpCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "up",
+		Run: runUp,
+	}
+	cmd.Flags().IntVarP(&nodes, "nodes", "n", 1, "number of nodes to spawn")
+	return cmd
+}
+
+func runDown(cmf *cobra.Command, args []string) {
+	log.Fatal("Not implemented yet. Please remove the containers by machinectl.")
+}
+
+func newDownCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "down",
+		Run: runDown,
+	}
+	return cmd
+}
+
+func newKubeadmSystemdCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "kubeadm-systemd",
+		Short: "kubeadm-systemd is a tool for creating a multi-node dev Kubernetes cluster",
+		Long:  "kubeadm-systemd is a tool for creating a multi-node dev Kubernetes cluster, by using the local source code and systemd-nspawn containers",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cmd.Usage(); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+	cmd.AddCommand(newUpCommand())
+	cmd.AddCommand(newDownCommand())
+	return cmd
+}
+
+func getContainerName(no int) string {
+	return fmt.Sprintf(containerNameTemplate, no)
+}
+
+func main() {
+	if err := newKubeadmSystemdCommand().Execute(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/etc/kubeadm.yaml
+++ b/etc/kubeadm.yaml
@@ -1,0 +1,1 @@
+AuthorizationMode: AlwaysAllow

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,96 @@
+hash: 4fd9333c7f68ff1e551b0eb267aa915335782206a8501906e48ffc62e0400c1d
+updated: 2017-01-27T15:33:09.639904031+01:00
+imports:
+- name: github.com/containernetworking/cni
+  version: 5c3c17164270150467498a32c71436c7cd5501be
+  subpackages:
+  - pkg/ns
+  - pkg/types
+- name: github.com/docker/distribution
+  version: 7a0972304e201e2a5336a69d00e112c27823f554
+  subpackages:
+  - digestset
+  - reference
+- name: github.com/docker/docker
+  version: fe5f49685df0d52127158f7e9a2882b8c4168dab
+  subpackages:
+  - api/types
+  - api/types/blkiodev
+  - api/types/container
+  - api/types/events
+  - api/types/filters
+  - api/types/mount
+  - api/types/network
+  - api/types/reference
+  - api/types/registry
+  - api/types/strslice
+  - api/types/swarm
+  - api/types/time
+  - api/types/versions
+  - api/types/volume
+  - client
+  - pkg/tlsconfig
+- name: github.com/docker/go-connections
+  version: eb315e36415380e7c2fdee175262560ff42359da
+  subpackages:
+  - nat
+  - sockets
+  - tlsconfig
+- name: github.com/docker/go-units
+  version: e30f1e79f3cd72542f2026ceec18d3bd67ab859c
+- name: github.com/dsnet/compress
+  version: b9aab3c6a04eef14c56384b4ad065e7b73438862
+  subpackages:
+  - bzip2
+  - bzip2/internal/sais
+  - internal
+  - internal/prefix
+- name: github.com/inconshreveable/mousetrap
+  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/mholt/archiver
+  version: 24d540239654d76e79c8f4e3d5bd56d90712becb
+- name: github.com/Microsoft/go-winio
+  version: 307e919c663683a9000576fdc855acaf9534c165
+- name: github.com/nwaples/rardecode
+  version: f22b7ef81a0afac9ce1447d37e5ab8e99fbd2f73
+- name: github.com/opencontainers/go-digest
+  version: 21dfd564fd89c944783d00d069f33e3e7123c448
+- name: github.com/pkg/errors
+  version: 248dadf4e9068a0b3e79f02ed0a610d935de5302
+- name: github.com/Sirupsen/logrus
+  version: 61e43dc76f7ee59a82bdf3d71033dc12bea4c77d
+- name: github.com/spf13/cobra
+  version: c29ece4386f74084680e5e6d02d7b943ae630f63
+- name: github.com/spf13/pflag
+  version: a9a634f3de0a7529baded7ad6b0c7467d5c6eca7
+- name: github.com/ulikunitz/xz
+  version: 76f94b7c69c6f84be96bcfc2443042b198689565
+  subpackages:
+  - internal/hash
+  - internal/xlog
+  - lzma
+- name: github.com/vishvananda/netlink
+  version: a4f22d8ad2327663017dbb309b5e3f8b6f348020
+  subpackages:
+  - nl
+- name: github.com/vishvananda/netns
+  version: 8ba1072b58e0c2a240eb5f6120165c7776c3e7b8
+- name: golang.org/x/crypto
+  version: 41d678d1df78cd0410143162dff954e6dc09300f
+  subpackages:
+  - curve25519
+  - ed25519
+  - ed25519/internal/edwards25519
+  - ssh
+- name: golang.org/x/net
+  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
+  subpackages:
+  - context
+  - context/ctxhttp
+  - proxy
+- name: golang.org/x/sys
+  version: e11762ca30adc5b39fdbfd8c4250dabeb8e456d3
+  subpackages:
+  - unix
+  - windows
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,6 @@
+package: github.com/kinvolk/kubeadm-systemd
+import:
+- package: github.com/mholt/archiver
+- package: golang.org/x/crypto
+  subpackages:
+  - ssh

--- a/pkg/bootstrap/bridge.go
+++ b/pkg/bootstrap/bridge.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"os"
+	"syscall"
+
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	brName string = "cni0"
+)
+
+func EnsureBridge() error {
+	if _, err := netlink.LinkByName(brName); err == nil {
+		return nil
+	}
+
+	pid, err := syscall.ForkExec("cni-noop", nil, &syscall.ProcAttr{
+		Dir:   "",
+		Env:   os.Environ(),
+		Files: []uintptr{uintptr(syscall.Stdout), uintptr(syscall.Stderr)},
+		Sys:   &syscall.SysProcAttr{},
+	})
+	if err != nil {
+		return err
+	}
+
+	var status syscall.WaitStatus
+	var rusage syscall.Rusage
+	if _, err := syscall.Wait4(pid, &status, 0, &rusage); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/bootstrap/container.go
+++ b/pkg/bootstrap/container.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"syscall"
+
+	"github.com/kinvolk/kubeadm-systemd/pkg/ssh"
+)
+
+var (
+	scripts []string = []string{"bootstrap.sh", "init.sh", "weave-daemonset.yaml"}
+)
+
+func copyScript(src, dest string) error {
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func prepareScript(containerName, scriptName string) error {
+	src := path.Join("scripts", scriptName)
+	dest := path.Join(containerName, "root", scriptName)
+
+	if err := copyScript(src, dest); err != nil {
+		return err
+	}
+
+	return os.Chmod(dest, 0755)
+}
+
+func prepareScripts(containerName string) error {
+	for _, script := range scripts {
+		if err := prepareScript(containerName, script); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ContainerRootfsExists(name string) (bool, error) {
+	if _, err := os.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func BootstrapContainer(name string) error {
+	if err := installBinaries(name); err != nil {
+		return err
+	}
+	if err := installCniBinaries(name); err != nil {
+		return err
+	}
+	if err := installSystemdUnits(name); err != nil {
+		return err
+	}
+	if err := installKubeletConfig(name); err != nil {
+		return err
+	}
+
+	if err := prepareScripts(name); err != nil {
+		return err
+	}
+
+	systemdNspawn, err := exec.LookPath("systemd-nspawn")
+	if err != nil {
+		return err
+	}
+
+	nspawnBootstrapArgs := []string{systemdNspawn, "-D", name, "/root/bootstrap.sh"}
+
+	pid, err := syscall.ForkExec(systemdNspawn, nspawnBootstrapArgs, &syscall.ProcAttr{
+		Dir:   "",
+		Env:   os.Environ(),
+		Files: []uintptr{uintptr(syscall.Stdin), uintptr(syscall.Stdout), uintptr(syscall.Stderr)},
+		Sys:   &syscall.SysProcAttr{},
+	})
+	if err != nil {
+		return err
+	}
+
+	var status syscall.WaitStatus
+	var rusage syscall.Rusage
+	if _, err := syscall.Wait4(pid, &status, 0, &rusage); err != nil {
+		return err
+	}
+
+	if err := ssh.PrepareAuthorizedKeys(name); err != nil {
+		return err
+	}
+
+	log.Println("Bootstraped container")
+
+	return nil
+}

--- a/pkg/bootstrap/kubernetes.go
+++ b/pkg/bootstrap/kubernetes.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"regexp"
+)
+
+var (
+	gopath            string = os.Getenv("GOPATH")
+	binariesDir       string = path.Join(gopath, "src", "k8s.io", "kubernetes", "_output", "bin")
+	binariesDest      string = path.Join("usr", "bin")
+	cniDir            string = path.Join(gopath, "src", "github.com", "containernetworking", "cni", "bin")
+	cniDest           string = path.Join("opt", "cni", "bin")
+	kubeletConfigPath string = path.Join(gopath, "src", "k8s.io", "release", "rpm", "10-kubeadm.conf")
+	kubeletConfigDest string = path.Join("etc", "systemd", "system", "kubelet.service.d", "10-kubeadm.conf")
+	systemdUnitDir    string = path.Join(gopath, "src", "k8s.io", "kubernetes", "build", "debs")
+	systemdUnitDest   string = path.Join("usr", "lib", "systemd", "system")
+)
+
+func installFile(containerName, filePath, dest string) error {
+	installPath, err := exec.LookPath("install")
+	if err != nil {
+		return err
+	}
+
+	dest = path.Join(containerName, dest)
+
+	args := []string{
+		installPath,
+		"-D",
+		filePath,
+		dest,
+	}
+
+	c := exec.Cmd{
+		Path:   installPath,
+		Args:   args,
+		Dir:    "",
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+	if err := c.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func installBinary(containerName, binaryPath string) error {
+	fullPath := path.Join(binariesDir, binaryPath)
+	return installFile(containerName, fullPath, binariesDest)
+}
+
+func installSystemdUnit(containerName, systemdUnitPath string) error {
+	fullPath := path.Join(systemdUnitDir, systemdUnitPath)
+	return installFile(containerName, fullPath, systemdUnitDest)
+}
+
+func installBinaries(containerName string) error {
+	binaries, err := ioutil.ReadDir(binariesDir)
+	if err != nil {
+		return err
+	}
+
+	for _, binary := range binaries {
+		if err := installBinary(containerName, binary.Name()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func installCniBinary(containerName, binaryPath string) error {
+	fullPath := path.Join(cniDir, binaryPath)
+	fullDest := path.Join(cniDest, binaryPath)
+	return installFile(containerName, fullPath, fullDest)
+}
+
+func installCniBinaries(containerName string) error {
+	binaries, err := ioutil.ReadDir(cniDir)
+	if err != nil {
+		return err
+	}
+
+	for _, binary := range binaries {
+		if err := installCniBinary(containerName, binary.Name()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func installKubeletConfig(containerName string) error {
+	return installFile(containerName, kubeletConfigPath, kubeletConfigDest)
+}
+
+func installSystemdUnits(containerName string) error {
+	distFiles, err := ioutil.ReadDir(systemdUnitDir)
+	if err != nil {
+		return err
+	}
+
+	r, err := regexp.Compile(".service$")
+	if err != nil {
+		return err
+	}
+
+	for _, distFile := range distFiles {
+		if !r.MatchString(distFile.Name()) {
+			continue
+		}
+
+		if err := installSystemdUnit(containerName, distFile.Name()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/cnispawn/netns.go
+++ b/pkg/cnispawn/netns.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cnispawn
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/containernetworking/cni/pkg/ns"
+)
+
+var (
+	gopath string = os.Getenv("GOPATH")
+)
+
+type CniNetns struct {
+	netns ns.NetNS
+}
+
+func NewCniNetns() (*CniNetns, error) {
+	netns, err := ns.NewNS()
+	if err != nil {
+		return nil, err
+	}
+
+	sNetnsPath := strings.Split(netns.Path(), "/")
+	containerId := sNetnsPath[len(sNetnsPath)-1]
+
+	cniPath := path.Join(gopath, "src", "github.com", "containernetworking", "cni", "bin")
+	cniPluginPath := path.Join(cniPath, "bridge")
+
+	env := os.Environ()
+	env = append(env, "CNI_COMMAND=ADD")
+	env = append(env, fmt.Sprintf("CNI_CONTAINERID=%s", containerId))
+	env = append(env, fmt.Sprintf("CNI_NETNS=%s", netns.Path()))
+	env = append(env, "CNI_IFNAME=eth0")
+	env = append(env, fmt.Sprintf("CNI_PATH=%s", cniPath))
+
+	c := exec.Cmd{
+		Path:   cniPluginPath,
+		Args:   nil,
+		Env:    env,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	stdin, err := c.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	netconfig, err := ioutil.ReadFile("/etc/cni/net.d/10-mynet.conf")
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := stdin.Write(netconfig); err != nil {
+		return nil, err
+	}
+	stdin.Close()
+
+	if err := c.Run(); err != nil {
+		return nil, err
+	}
+
+	return &CniNetns{
+		netns: netns,
+	}, nil
+}
+
+func (c *CniNetns) Set() error {
+	return c.netns.Set()
+}
+
+func (c *CniNetns) Close() error {
+	return c.netns.Close()
+}

--- a/pkg/cnispawn/spawn.go
+++ b/pkg/cnispawn/spawn.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cnispawn
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"syscall"
+)
+
+func RunContainer(path string, background bool) error {
+	runtime.LockOSThread()
+
+	cniNetns, err := NewCniNetns()
+	if err != nil {
+		return err
+	}
+
+	if err := cniNetns.Set(); err != nil {
+		return err
+	}
+	defer cniNetns.Close()
+
+	systemdNspawnPath := os.Getenv("SYSTEMD_NSPAWN_PATH")
+
+	if systemdNspawnPath == "" {
+		systemdNspawnPath, err = exec.LookPath("systemd-nspawn")
+		if err != nil {
+			return err
+		}
+	}
+
+	// TODO(nhlfr): Don't hardcode kubeadm-systemd specific options,
+	// expose all the options of systemd-nspawn instead.
+	args := []string{
+		systemdNspawnPath,
+		"--capability=cap_audit_control,cap_audit_read,cap_audit_write,cap_audit_control,cap_block_suspend,cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_ipc_lock,cap_ipc_owner,cap_kill,cap_lease,cap_linux_immutable,cap_mac_admin,cap_mac_override,cap_mknod,cap_net_admin,cap_net_bind_service,cap_net_broadcast,cap_net_raw,cap_setgid,cap_setfcap,cap_setpcap,cap_setuid,cap_sys_admin,cap_sys_boot,cap_sys_chroot,cap_sys_module,cap_sys_nice,cap_sys_pacct,cap_sys_ptrace,cap_sys_rawio,cap_sys_resource,cap_sys_time,cap_sys_tty_config,cap_syslog,cap_wake_alarm",
+		// "--bind=/proc/sys/net/bridge",
+		// "--capability=cap_audit_write,cap_audit_control,cap_sys_admin,cap_sys_chroot,cap_net_admin,cap_setfcap,cap_syslog",
+		"--bind=/sys/fs/cgroup",
+		"--bind-ro=/boot",
+		"--bind-ro=/lib/modules",
+		"-bD",
+		path,
+	}
+
+	env := os.Environ()
+	// env = append(env, "SYSTEMD_NSPAWN_MOUNT_RW=true")
+	env = append(env, "SYSTEMD_NSPAWN_API_VFS_WRITABLE=true")
+
+	if background {
+		_, err := syscall.ForkExec(systemdNspawnPath, args, &syscall.ProcAttr{
+			Dir:   "",
+			Env:   env,
+			Files: []uintptr{},
+			Sys:   &syscall.SysProcAttr{},
+		})
+		return err
+	}
+	return syscall.Exec(systemdNspawnPath, args, env)
+}

--- a/pkg/distribution/registry.go
+++ b/pkg/distribution/registry.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package distribution
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
+	networktypes "github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+)
+
+func StartRegistry() error {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return err
+	}
+
+	readerCloser, err := cli.ImagePull(context.Background(), "docker.io/library/registry:2", types.ImagePullOptions{
+		All: true,
+		// RegistryAuth header cannot be empty, even if no authentication is used at all...
+		RegistryAuth: "123",
+	})
+	if err != nil {
+		return err
+	}
+	defer readerCloser.Close()
+
+	bufReader := bufio.NewReader(readerCloser)
+
+	for {
+		line, _, err := bufReader.ReadLine()
+		if err != io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		var jsonLine map[string]interface{}
+		if err := json.Unmarshal(line, &jsonLine); err != nil {
+			return err
+		}
+
+		fmt.Println(string(line[:]))
+	}
+
+	if _, err := cli.ContainerCreate(context.Background(), &containertypes.Config{
+		Image: "registry:2",
+	}, &containertypes.HostConfig{
+		PortBindings: nat.PortMap{"5000/tcp": []nat.PortBinding{nat.PortBinding{
+			HostIP:   "0.0.0.0",
+			HostPort: "5000",
+		}}},
+	}, &networktypes.NetworkingConfig{}, "registry"); err != nil && !strings.Contains(err.Error(), "Conflict") {
+		return err
+	}
+
+	// return cli.ContainerStart(context.Background(), container.ID, types.ContainerStartOptions{})
+	return cli.ContainerStart(context.Background(), "registry", types.ContainerStartOptions{})
+}
+
+func PushImage() error {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return err
+	}
+
+	if err := cli.ImageTag(
+		context.Background(),
+		"gcr.io/google_containers/hyperkube-amd64",
+		"10.22.0.1:5000/hyperkube-amd64",
+	); err != nil {
+		return err
+	}
+
+	readerCloser, err := cli.ImagePush(context.Background(), "10.22.0.1:5000/hyperkube-amd64", types.ImagePushOptions{
+		All: true,
+		// RegistryAuth header cannot be empty, even if no authentication is used at all...
+		RegistryAuth: "123",
+	})
+	if err != nil {
+		return err
+	}
+	defer readerCloser.Close()
+
+	bufReader := bufio.NewReader(readerCloser)
+
+	for {
+		line, _, err := bufReader.ReadLine()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		var jsonLine map[string]interface{}
+		if err := json.Unmarshal(line, &jsonLine); err != nil {
+			return err
+		}
+
+		if errMsg, ok := jsonLine["error"]; ok {
+			if errMsgStr, ok := errMsg.(string); ok {
+				return fmt.Errorf(errMsgStr)
+			}
+		}
+
+		if progress, ok := jsonLine["progress"]; ok {
+			fmt.Println(progress)
+		}
+		// fmt.Println(string(line[:]))
+	}
+
+	return nil
+}

--- a/pkg/nspawntool/image.go
+++ b/pkg/nspawntool/image.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nspawntool
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/mholt/archiver"
+)
+
+const (
+	centosImageUrl string = "https://uk.images.linuxcontainers.org/images/centos/7/amd64/default/20170131_02:16/rootfs.tar.xz"
+)
+
+func DownloadImage() error {
+	if _, err := os.Stat("rootfs.tar.xz"); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+	} else {
+		return nil
+	}
+
+	imageFile, err := os.Create("rootfs.tar.xz")
+	if err != nil {
+		return err
+	}
+	defer imageFile.Close()
+
+	response, err := http.Get(centosImageUrl)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if _, err := io.Copy(imageFile, response.Body); err != nil {
+		return err
+	}
+
+	log.Println("Downloaded file")
+
+	return nil
+}
+
+func ExtractImage(dest string) error {
+	return archiver.TarXZ.Open("rootfs.tar.xz", dest)
+}

--- a/pkg/nspawntool/run.go
+++ b/pkg/nspawntool/run.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nspawntool
+
+import (
+	"bufio"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+)
+
+func RunContainer(name string) (string, error) {
+	args := []string{
+		"cnispawn",
+		"-path",
+		name,
+	}
+
+	c := exec.Cmd{
+		Path:   "cnispawn",
+		Args:   args,
+		Env:    os.Environ(),
+		Stderr: os.Stderr,
+	}
+
+	stdout, err := c.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+
+	if err := c.Start(); err != nil {
+		return "", err
+	}
+
+	cniDataJson, err := ioutil.ReadAll(bufio.NewReader(stdout))
+	if err != nil {
+		return "", err
+	}
+
+	var cniData cnitypes.Result
+	if err := json.Unmarshal(cniDataJson, &cniData); err != nil {
+		return "", err
+	}
+
+	if err := c.Wait(); err != nil {
+		var cniError cnitypes.Error
+		if err := json.Unmarshal(cniDataJson, &cniError); err == nil {
+			return "", &cniError
+		}
+		return "", err
+	}
+
+	log.Printf("Container %s running\n", name)
+	return cniData.IP4.IP.IP.String(), nil
+}

--- a/pkg/ssh/connection.go
+++ b/pkg/ssh/connection.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssh
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	sshConnRetries int = 10
+)
+
+func getSession(ipAddress string) (*ssh.Session, error) {
+	var conn *ssh.Client
+	var err error
+
+	auth, err := getPublicKey()
+	if err != nil {
+		return nil, err
+	}
+
+	config := &ssh.ClientConfig{
+		User: "root",
+		Auth: []ssh.AuthMethod{auth},
+	}
+
+	sshUri := fmt.Sprintf("%s:22", ipAddress)
+	for i := 0; i < sshConnRetries; i++ {
+		conn, err = ssh.Dial("tcp", sshUri, config)
+		if err == nil {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	session, err := conn.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	modes := ssh.TerminalModes{
+		ssh.ECHO:          0,
+		ssh.TTY_OP_ISPEED: 14400,
+		ssh.TTY_OP_OSPEED: 14400,
+	}
+
+	if err := session.RequestPty("xterm", 80, 40, modes); err != nil {
+		session.Close()
+		return nil, err
+	}
+
+	return session, nil
+}
+
+func executeCommand(ipAddress, command string) error {
+	session, err := getSession(ipAddress)
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	session.Stdout = os.Stdout
+
+	return session.Run(command)
+}

--- a/pkg/ssh/key.go
+++ b/pkg/ssh/key.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssh
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	privKeyPath string = "id_rsa"
+	pubKeyPath  string = "id_rsa.pub"
+)
+
+func generateSSHKeys() error {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+
+	privKeyFile, err := os.Create(privKeyPath)
+	if err != nil {
+		return err
+	}
+	defer privKeyFile.Close()
+
+	privKeyPem := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privKey)}
+	if err := pem.Encode(privKeyFile, privKeyPem); err != nil {
+		return err
+	}
+
+	pubKey, err := ssh.NewPublicKey(&privKey.PublicKey)
+	if err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(pubKeyPath, ssh.MarshalAuthorizedKey(pubKey), 0600); err != nil {
+		return err
+	}
+
+	log.Println("Generated SSH keypair")
+
+	return nil
+}
+
+func chmodSSHKeys() error {
+	return os.Chmod(privKeyPath, 0600)
+}
+
+func keysExist() (bool, error) {
+	if _, err := os.Stat(privKeyPath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func PrepareSSHKeys() error {
+	exist, err := keysExist()
+	if err != nil {
+		return err
+	}
+	if exist {
+		return nil
+	}
+
+	if err := generateSSHKeys(); err != nil {
+		return err
+	}
+	return chmodSSHKeys()
+}
+
+func getSSHPath(name string) string {
+	return path.Join(name, "root", ".ssh")
+}
+
+func createAuthorizedKeys(name string) error {
+	sshPath := getSSHPath(name)
+	if err := os.Mkdir(sshPath, 0700); err != nil {
+		return err
+	}
+
+	authorizedKeysPath := path.Join(sshPath, "authorized_keys")
+	out, err := os.Create(authorizedKeysPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	in, err := os.Open(pubKeyPath)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func chmodAuthorizedKeys(name string) error {
+	authorizedKeysPath := path.Join(getSSHPath(name), "authorized_keys")
+	return os.Chmod(authorizedKeysPath, 0600)
+}
+
+func PrepareAuthorizedKeys(name string) error {
+	if err := createAuthorizedKeys(name); err != nil {
+		return err
+	}
+	return chmodAuthorizedKeys(name)
+}
+
+func getPublicKey() (ssh.AuthMethod, error) {
+	buf, err := ioutil.ReadFile(privKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := ssh.ParsePrivateKey(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return ssh.PublicKeys(key), nil
+}

--- a/pkg/ssh/kubeadm.go
+++ b/pkg/ssh/kubeadm.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssh
+
+import (
+	"fmt"
+	"log"
+)
+
+func InitializeMaster(ipAddress string) error {
+	log.Println("Initializing master")
+
+	return executeCommand(ipAddress, "./init.sh")
+}
+
+func JoinNode(ipAddress, token, masterIpAddress string) error {
+	log.Println("Joining node")
+
+	command := fmt.Sprintf("kubeadm reset && KUBE_HYPERKUBE_IMAGE=10.22.0.1:5000/hyperkube-amd64 kubeadm join --discovery token://%s@%s:9898 --config /etc/kubeadm/kubeadm.yml --skip-preflight-checks", token, masterIpAddress)
+	return executeCommand(ipAddress, command)
+}

--- a/pkg/utils/token.go
+++ b/pkg/utils/token.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2017 Kinvolk GmbH
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"path"
+)
+
+func GetToken(containerName string) (string, error) {
+	tokenFilePath := path.Join(containerName, "etc", "kubernetes", "pki", "tokens.csv")
+	f, err := os.Open(tokenFilePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	lines, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		return "", err
+	}
+
+	for _, line := range lines {
+		for _, row := range line {
+			return row, nil
+		}
+	}
+
+	return "", fmt.Errorf("No token generated")
+}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+echo "kubernetes" | passwd --stdin root
+
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
+yum -y install \
+	docker \
+	openssh-server \
+	bind-utils \
+	ebtables \
+	ethtool \
+	net-tools \
+	socat \
+	strace \
+	jq \
+	wget \
+	iproute \
+	util-linux \
+	tmux
+
+cat >>/etc/sysconfig/docker <<-EOF
+INSECURE_REGISTRY='--insecure-registry=10.22.0.1:5000'
+EOF
+
+systemctl daemon-reload
+systemctl enable docker.service
+systemctl enable sshd.service
+
+mkdir -p /etc/kubeadm
+cat >/etc/kubeadm/kubeadm.yml <<-EOF
+AuthorizationMode: AlwaysAllow
+KubernetesVersion: latest
+EOF

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+kubeadm reset
+KUBE_HYPERKUBE_IMAGE=10.22.0.1:5000/hyperkube-amd64 kubeadm init --skip-preflight-checks --config /etc/kubeadm/kubeadm.yml
+kubectl -n kube-system get ds -l 'component=kube-proxy' -o json | jq '.items[0].spec.template.spec.containers[0].command |= .+ ["--conntrack-max-per-core=0"]' | kubectl apply -f - && kubectl -n kube-system delete pods -l 'component=kube-proxy'
+kubectl apply -f weave-daemonset.yaml

--- a/scripts/weave-daemonset.yaml
+++ b/scripts/weave-daemonset.yaml
@@ -1,0 +1,75 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: weave-net
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        name: weave-net
+      annotations:
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [
+            {
+              "key": "dedicated",
+              "operator": "Equal",
+              "value": "master",
+              "effect": "NoSchedule"
+            }
+          ]
+    spec:
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: weave
+          image: weaveworks/weave-kube:git-84013c4452d1
+          imagePullPolicy: Always
+          command:
+            - /home/weave/launch.sh
+          livenessProbe:
+            initialDelaySeconds: 30
+            httpGet:
+              host: 127.0.0.1
+              path: /status
+              port: 6784
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: weavedb
+              mountPath: /weavedb
+            - name: cni-bin
+              mountPath: /host/opt
+            - name: cni-bin2
+              mountPath: /host/home
+            - name: cni-conf
+              mountPath: /host/etc
+            - name: dbus
+              mountPath: /host/var/lib/dbus
+          resources:
+            requests:
+              cpu: 10m
+        - name: weave-npc
+          image: weaveworks/weave-npc:git-84013c4452d1
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 10m
+          securityContext:
+            privileged: true
+      restartPolicy: Always
+      volumes:
+        - name: weavedb
+          emptyDir: {}
+        - name: cni-bin
+          hostPath:
+            path: /opt
+        - name: cni-bin2
+          hostPath:
+            path: /home
+        - name: cni-conf
+          hostPath:
+            path: /etc
+        - name: dbus
+          hostPath:
+            path: /var/lib/dbus


### PR DESCRIPTION
A small CLI tool for downloading CentOS container image, spawning the containers, configuring a Docker daemon on them and setting up k8s cluster by kubeadm (via Ansible).

---

TODO:
- [x] Spawn "nodes" (systemd-nspawn containers)
- [x] Use CNI for providing networking to the nspawn containers
- [x] Bootstrap nodes - set up Docker and OpenSSH daemon
- [x] Distribute binaries / hyperkube image built from k8s sources on host
- [x] Run kubeadm on the nodes (machinectl shell, or machinectl login, or SSH, depends on what solution will work)