### PR TITLE
kubeadm-nspawn: init: fix panic, index out of range

### DIFF
--- a/cmd/kubeadm-nspawn/kubeadm-nspawn.go
+++ b/cmd/kubeadm-nspawn/kubeadm-nspawn.go
@@ -112,6 +112,9 @@ func runInit(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal("Error listing running nodes: ", err)
 	}
+	if len(nodes) == 0 {
+		log.Fatal("No node running. Is systemd-nspawn running correctly?")
+	}
 
 	token, err := ssh.InitializeMaster(nodes[0].IP.String())
 	if err != nil {


### PR DESCRIPTION
When systemd-nspawn is not running, there are no nodes. Don't
dereference the first node.

Symptoms:
```
| $ sudo ./kubeadm-nspawn init
| 2017/06/14 14:33:09 Warning: experimental!
| panic: runtime error: index out of range
|
| goroutine 1 [running]:
| panic(0x556b46226c80, 0xc4200100f0)
| 	/usr/lib/go-1.7/src/runtime/panic.go:500 +0x1a1
| main.runInit(0xc420073440, 0x556b46746dc8, 0x0, 0x0)
| 	/go/src/github.com/kinvolk/kubeadm-nspawn/cmd/kubeadm-nspawn/kubeadm-nspawn.go:116 +0x4da
| github.com/kinvolk/kubeadm-nspawn/vendor/github.com/spf13/cobra.(*Command).execute(0xc420073440, 0x556b46746dc8, 0x0, 0x0, 0xc420073440, 0x556b46746dc8)
| 	/go/src/github.com/kinvolk/kubeadm-nspawn/vendor/github.com/spf13/cobra/command.go:647 +0x443
| github.com/kinvolk/kubeadm-nspawn/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc420072fc0, 0xc420073680, 0xc420073440, 0xc420073200)
| 	/go/src/github.com/kinvolk/kubeadm-nspawn/vendor/github.com/spf13/cobra/command.go:734 +0x367
| github.com/kinvolk/kubeadm-nspawn/vendor/github.com/spf13/cobra.(*Command).Execute(0xc420072fc0, 0x556b45d82a4a, 0x556b462b4dea)
| 	/go/src/github.com/kinvolk/kubeadm-nspawn/vendor/github.com/spf13/cobra/command.go:692 +0x2b
| main.main()
| 	/go/src/github.com/kinvolk/kubeadm-nspawn/cmd/kubeadm-nspawn/kubeadm-nspawn.go:205 +0x33
```

Fixes https://github.com/kinvolk/kubeadm-nspawn/issues/33