### PR TITLE
pkg/nspawntool: give the masterIP parameter to join*.sh

### DIFF
--- a/pkg/nspawntool/kubeadm.go
+++ b/pkg/nspawntool/kubeadm.go
@@ -23,5 +23,6 @@ func JoinNode(k8srelease, name, masterIP string) error {
 	if k8srelease != "" {
 		cmd = []string{"/opt/kubeadm-nspawn/join-release.sh"}
 	}
+	cmd = append(cmd, masterIP)
 	return bootstrap.Exec(nil, os.Stdout, os.Stderr, name, cmd...)
 }


### PR DESCRIPTION
`join*.sh` needs to run with an additional parater for the master IP. Otherwise it could not run correctly.

Fixes https://github.com/kinvolk/kubeadm-nspawn/issues/48